### PR TITLE
Fix/improve scripts

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -3,7 +3,7 @@ import { log } from '../utils';
 import { ENV } from '../env';
 
 const client = new Client({
-  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMembers],
+  intents: [GatewayIntentBits.Guilds],
 });
 
 client.login(ENV.BOT_TOKEN).catch((err) => {

--- a/src/commands/general/info.ts
+++ b/src/commands/general/info.ts
@@ -32,18 +32,21 @@ const meta = new SlashCommandBuilder()
   .addSubcommand(bot)
   .addSubcommand(user);
 
-export default command({ meta }, async ({ interaction, ...props }) => {
-  await interaction.deferReply({ ephemeral: true });
+export default command(
+  { meta, private: true },
+  async ({ interaction, ...props }) => {
+    await interaction.deferReply({ ephemeral: true });
 
-  switch (interaction.options.getSubcommand()) {
-    case 'server':
-      return await getServerInfo({ interaction, ...props });
-    case 'bot':
-      return await getBotInfo({ interaction, ...props });
-    case 'user':
-      return await getUserInfo({ interaction, ...props });
+    switch (interaction.options.getSubcommand()) {
+      case 'server':
+        return await getServerInfo({ interaction, ...props });
+      case 'bot':
+        return await getBotInfo({ interaction, ...props });
+      case 'user':
+        return await getUserInfo({ interaction, ...props });
+    }
   }
-});
+);
 
 const getServerInfo = async ({ interaction }: CommandProps) => {
   const owner = await interaction.guild?.fetchOwner();

--- a/src/commands/general/info.ts
+++ b/src/commands/general/info.ts
@@ -32,21 +32,18 @@ const meta = new SlashCommandBuilder()
   .addSubcommand(bot)
   .addSubcommand(user);
 
-export default command(
-  { meta, private: true },
-  async ({ interaction, ...props }) => {
-    await interaction.deferReply({ ephemeral: true });
+export default command({ meta }, async ({ interaction, ...props }) => {
+  await interaction.deferReply({ ephemeral: true });
 
-    switch (interaction.options.getSubcommand()) {
-      case 'server':
-        return await getServerInfo({ interaction, ...props });
-      case 'bot':
-        return await getBotInfo({ interaction, ...props });
-      case 'user':
-        return await getUserInfo({ interaction, ...props });
-    }
+  switch (interaction.options.getSubcommand()) {
+    case 'server':
+      return await getServerInfo({ interaction, ...props });
+    case 'bot':
+      return await getBotInfo({ interaction, ...props });
+    case 'user':
+      return await getUserInfo({ interaction, ...props });
   }
-);
+});
 
 const getServerInfo = async ({ interaction }: CommandProps) => {
   const owner = await interaction.guild?.fetchOwner();

--- a/src/scripts/clear.ts
+++ b/src/scripts/clear.ts
@@ -1,9 +1,10 @@
 import 'dotenv/config';
 import { REST, Routes, APIUser } from 'discord.js';
 import { ENV } from '../env';
-import { log } from '../utils';
+import { Logger } from '../utils';
 
 const rest = new REST({ version: '10' }).setToken(ENV.BOT_TOKEN);
+const logger = new Logger('clear');
 
 async function main() {
   const currentUser = (await rest.get(Routes.user())) as APIUser;
@@ -20,6 +21,6 @@ async function main() {
 main()
   .then((user) => {
     const tag = `${user.username}#${user.discriminator}`;
-    log.system('clear', `Commands cleared for \x1b[4m${tag}\x1b[0m\x1b[36m!`);
+    logger.system(`Commands cleared for \x1b[4m${tag}\x1b[0m\x1b[36m!`);
   })
-  .catch(console.error);
+  .catch((e) => logger.error(e));

--- a/src/scripts/deploy.ts
+++ b/src/scripts/deploy.ts
@@ -2,9 +2,10 @@ import 'dotenv/config';
 import { REST, Routes, APIUser } from 'discord.js';
 import categories from '../commands';
 import { ENV } from '../env';
-import { extractMeta, log } from '../utils';
+import { Logger, extractMeta } from '../utils';
 
 const rest = new REST({ version: '10' }).setToken(ENV.BOT_TOKEN);
+const logger = new Logger('deploy');
 
 async function main() {
   const currentUser = (await rest.get(Routes.user())) as APIUser;
@@ -37,11 +38,10 @@ async function main() {
 main()
   .then((user) => {
     const tag = `${user.username}#${user.discriminator}`;
-    log.system(
-      'deploy',
+    logger.system(
       `Commands deployed for \x1b[4m${tag}\x1b[0m\x1b[36m${
         ENV.DEV ? ` in guild ${ENV.TEST_GUILD}` : ''
       }!`
     );
   })
-  .catch(console.error);
+  .catch((e) => logger.error(e));

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -31,3 +31,18 @@ export function category(
     },
   };
 }
+
+/**
+ * Extracts the metadata from a list of categories.
+ * @param categories The categories to extract metadata from.
+ * @param type The type of commands to extract metadata from (public, private, or all).
+ * @returns The extracted list of metadata.
+ */
+export function extractMeta(
+  categories: CommandCategory[],
+  type: keyof CommandCategory['commands']
+) {
+  return categories.flatMap(({ commands }) =>
+    commands[type].map(({ meta }) => meta)
+  );
+}


### PR DESCRIPTION
# Changes
- [x] Private commands will now be registered in the test guild only when running `npm run deploy-prod`
- [x] Both scripts (`deploy` and `clear`) now use a `Logger` instance for their logging
- [x] Removed the `GuildMembers` intent from the bot client (requires special permission, and is unnecessary unless you want to fetch all of the guild members at a time)