### PR TITLE
Feat/improve pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ export default command({ meta }, async ({ interaction }) => {
 });
 ```
 
+### Help command
+
+A `/help` command is provided out of the box, that automatically generates an embed that allows for navigating through all of the commands (and their subcommands and subcommand groups!).
+More information about this command can be found in the [Help menu](#help-menu) section.
+
 ### Command options
 
 The first argument of the `command()` function takes an object containing at least the `meta` object created using the `SlashCommandBuilder` from `discord.js`. There's some optional fields that can be passed into the object alongside the `meta` to further configure the command. The following optional fields are available:
@@ -103,10 +108,6 @@ The first argument of the `command()` function takes an object containing at lea
 - `adminOnly`: whether the command should only be available to users with the `ADMINISTRATOR` permission (default: `false`)
 
 When a command is _private_, it will only be registered in the test guild, never in any other servers. This could be useful for commands that you, as the bot creator, want to use, but do not want others to use, such as stats about the bot.
-
-### Help command
-
-A `/help` command is already provided in the [`src/commands/general/help.ts`](./src/commands/general/help.ts) file, which automatically generates an embed that allows for navigating through all of the commands (and their subcommands and subcommand groups!) and their descriptions, using the pagination functionality described in section [Pagination](#pagination). This will show _ALL_ of the (public) commands, including their subcommands, even if they're hidden away in subcommand groups, no matter how deeply nested they are.
 
 ### Subcommands
 
@@ -136,6 +137,14 @@ export default event('ready', ({ logger }, client) => {
   );
 });
 ```
+
+## Help menu
+
+A `/help` command is provided in the [`src/commands/general/help.ts`](./src/commands/general/help.ts) file, which automatically generates an embed that allows for navigating through all of the commands (and their subcommands and subcommand groups!).
+It uses the pagination functionality described in section [Pagination](#pagination).
+
+The command takes into account the options set on the commands, such as whether they are private (restricted to test guild) or admin-only, and only shows the commands that are applicable to the user using the command.
+If a command is private or admin-only, this will be shown in the help menu.
 
 ## Logging
 
@@ -179,9 +188,6 @@ There is built-in support for pagination of content using embeds. Currently, thi
 
 The pagination for the `/help` command uses a separate paginator for each category of commands, which are defined in the [`src/utils/paginators/help.ts`](./src/utils/paginators/help.ts) file.
 The pagination embed for a selected category is created in the [`src/events/interactionCreate/help.ts`](./src/events/interactionCreate/help.ts) file.
-
-The help command will show only the commands that are applicable to the user using the command. That is, in guilds other than the test guild (see the [Environment variables](#environment-variables) section), it will only show public commands, and in the test guild it will show all commands, including private commands.
-Additionally, if the member is an administrator, `adminOnly` commands as well.
 
 ### Caching pagination data
 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,23 @@ If you want these replies to use embeds by default, this can be easily changed b
 There is built-in support for pagination of content using embeds. Currently, this is only used in the `/help` command, but you can create your own pagination by following these steps:
 
 1. Create a paginator in the [`src/utils/paginators.ts`](./src/utils/paginators) folder, using the constructor of the `Paginator` class defined in [`src/utils/pagination.ts`](./src/utils/pagination.ts)
-2. Use the `paginationReply()` function from the utils to create an embed that can be used to navigate through the pages. Don't forget to await this function!
+2. Add the paginator you created to the `paginators` array in the [`src/utils/paginators/index.ts`](./src/utils/paginators/index.ts) file
+3. Use the `paginationReply()` function from the utils to create an embed that can be used to navigate through the pages. Don't forget to await this function!
 
 The pagination for the `/help` command uses a separate paginator for each category of commands, which are defined in the [`src/utils/paginators/help.ts`](./src/utils/paginators/help.ts) file. The pagination embed for a selected category is created in the [`src/events/interactionCreate/help.ts`](./src/events/interactionCreate/help.ts) file.
+
+### Caching pagination data
+
+The `Paginator` class takes a `getData()` function to fetch the data to paginate.
+It is passed a props object, whose type is defined in the [`src/types/pagination.ts`](./src/types/pagination.ts) file as `PaginationProps`.
+The props object currently contains the bot client and the interaction object, but you can add additional fields to it if you need to.
+
+To avoid having to fetch the data every time the page is changed, the `Paginator` class offers the option to cache the data by setting `cacheData` to `true` in the constructor.
+When you set this to `true`, you must also specify the `getCacheKey()` function in the constructor, which takes the props object and returns a string that is used as the key for the cache.
+The `getData()` function is then only called when the data is not yet cached, and the cached data is used otherwise.
+This allows you to cache the data for a specific user (and guild), for example, by using the user ID as the cache key.
+
+### Customizing pagination message
 
 The pagination uses embed fields to display the content, and thus the limit of items to show on a single page is 25 (the maximum number of fields allowed in an embed).
 You can customize the comopnents of the embed being sent using the `embedData` prop, except the fields and footer, since those are set by the pagination.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ If you want these replies to use embeds by default, this can be easily changed b
 There is built-in support for pagination of content using embeds. Currently, this is only used in the `/help` command, but you can create your own pagination by following these steps:
 
 1. Create a paginator in the [`src/utils/paginators.ts`](./src/utils/paginators) folder, using the constructor of the `Paginator` class defined in [`src/utils/pagination.ts`](./src/utils/pagination.ts)
-2. Use the `paginationEmbed()` function from the utils to create an embed that can be used to navigate through the pages
+2. Use the `paginationReply()` function from the utils to create an embed that can be used to navigate through the pages. Don't forget to await this function!
 
 The pagination for the `/help` command uses a separate paginator for each category of commands, which are defined in the [`src/utils/paginators/help.ts`](./src/utils/paginators/help.ts) file. The pagination embed for a selected category is created in the [`src/events/interactionCreate/help.ts`](./src/events/interactionCreate/help.ts) file.
 

--- a/README.md
+++ b/README.md
@@ -196,10 +196,12 @@ This allows you to cache the data for a specific user (and guild), for example, 
 ### Customizing pagination message
 
 The pagination uses embed fields to display the content, and thus the limit of items to show on a single page is 25 (the maximum number of fields allowed in an embed).
-You can customize the comopnents of the embed being sent using the `embedData` prop, except the fields and footer, since those are set by the pagination.
-Additionally, you can change the options of the reply message using the `replyOptions` prop.
+You can customize the components of the embed being sent using the optional `embedData` prop, except the fields and footer, since those are set by the pagination.
+Additionally, you can change the options of the reply message using the optional `replyOptions` prop.
 The pagination embed, the _next_ and _back_ buttons and the page selector will be added onto the given reply options to compose the final message.
 The reply is made ephemeral by default, so if you want it to not be ephemeral, you have to explicitly pass `ephemeral: false` to the `replyOptions`.
+
+_Note_: both the `embedData` and `replyOptions` props can either be the actual data, or a function that returns the data. The function is passed the props object, so you can use the props to determine the data to return.
 
 ## Interaction IDs
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ There is built-in support for pagination of content using embeds. Currently, thi
 The pagination for the `/help` command uses a separate paginator for each category of commands, which are defined in the [`src/utils/paginators/help.ts`](./src/utils/paginators/help.ts) file.
 The pagination embed for a selected category is created in the [`src/events/interactionCreate/help.ts`](./src/events/interactionCreate/help.ts) file.
 
-The help command only shows public commands, and hides private commands. It also hides `adminOnly` commands from users that are not administrators.
+The help command will show only the commands that are applicable to the user using the command. That is, in guilds other than the test guild (see the [Environment variables](#environment-variables) section), it will only show public commands, and in the test guild it will show all commands, including private commands.
+Additionally, if the member is an administrator, `adminOnly` commands as well.
 
 ### Caching pagination data
 

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ A command file should look something like this:
 
 ```ts
 import { SlashCommandBuilder } from 'discord.js';
-import { command } from '../../utils';
+import { command, reply } from '../../utils';
 
 const meta = new SlashCommandBuilder()
   .setName('example')
   .setDescription('Example command.');
 
 export default command({ meta }, async ({ interaction }) => {
-  await interaction.reply({
+  await reply(interaction, {
     ephemeral: true,
     content: 'Hello world!',
   });

--- a/README.md
+++ b/README.md
@@ -175,7 +175,12 @@ There is built-in support for pagination of content using embeds. Currently, thi
 2. Add the paginator you created to the `paginators` array in the [`src/utils/paginators/index.ts`](./src/utils/paginators/index.ts) file
 3. Use the `paginationReply()` function from the utils to create an embed that can be used to navigate through the pages. Don't forget to await this function!
 
-The pagination for the `/help` command uses a separate paginator for each category of commands, which are defined in the [`src/utils/paginators/help.ts`](./src/utils/paginators/help.ts) file. The pagination embed for a selected category is created in the [`src/events/interactionCreate/help.ts`](./src/events/interactionCreate/help.ts) file.
+### Help command pagination
+
+The pagination for the `/help` command uses a separate paginator for each category of commands, which are defined in the [`src/utils/paginators/help.ts`](./src/utils/paginators/help.ts) file.
+The pagination embed for a selected category is created in the [`src/events/interactionCreate/help.ts`](./src/events/interactionCreate/help.ts) file.
+
+The help command only shows public commands, and hides private commands. It also hides `adminOnly` commands from users that are not administrators.
 
 ### Caching pagination data
 

--- a/src/commands/debug/index.ts
+++ b/src/commands/debug/index.ts
@@ -2,6 +2,6 @@ import { category } from '../../utils';
 import ping from './ping';
 
 export default category(
-  { name: 'Debug', description: 'Commands used for debugging', emoji: '🐛' },
+  { name: 'Debug', description: 'Commands used for debugging.', emoji: '🐛' },
   [ping]
 );

--- a/src/commands/debug/ping.ts
+++ b/src/commands/debug/ping.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { command } from '../../utils';
+import { command, reply } from '../../utils';
 
 const meta = new SlashCommandBuilder()
   .setName('ping')
@@ -13,11 +13,14 @@ const meta = new SlashCommandBuilder()
       .setRequired(false)
   );
 
-export default command({ meta }, async ({ client, interaction }) => {
-  const message = interaction.options.getString('message');
+export default command(
+  { meta, private: true },
+  async ({ client, interaction }) => {
+    const message = interaction.options.getString('message');
 
-  await interaction.reply({
-    ephemeral: true,
-    content: `${message ?? 'Pong!'} (${client.ws.ping}ms)`,
-  });
-});
+    await reply(interaction, {
+      ephemeral: true,
+      content: `${message ?? 'Pong!'} (${client.ws.ping}ms)`,
+    });
+  }
+);

--- a/src/commands/general/help.ts
+++ b/src/commands/general/help.ts
@@ -1,5 +1,5 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
-import { command, helpSelectComponent } from '../../utils';
+import { command, helpSelectComponent, reply } from '../../utils';
 import { COLORS } from '../../constants';
 
 const meta = new SlashCommandBuilder()
@@ -14,9 +14,20 @@ export default command({ meta }, async ({ interaction }) => {
     )
     .setColor(COLORS.embed);
 
-  return await interaction.reply({
+  const helpSelectMenu = helpSelectComponent(interaction);
+  if (!helpSelectMenu) {
+    embed.setDescription(
+      'There are no commands available for you to use in this server.'
+    );
+    return await reply(interaction, {
+      embeds: [embed],
+      ephemeral: true,
+    });
+  }
+
+  return await reply(interaction, {
     embeds: [embed],
-    components: [helpSelectComponent(interaction)],
+    components: [helpSelectMenu],
     ephemeral: true,
   });
 });

--- a/src/commands/general/help.ts
+++ b/src/commands/general/help.ts
@@ -16,7 +16,7 @@ export default command({ meta }, async ({ interaction }) => {
 
   return await interaction.reply({
     embeds: [embed],
-    components: [helpSelectComponent],
+    components: [helpSelectComponent(interaction)],
     ephemeral: true,
   });
 });

--- a/src/commands/general/index.ts
+++ b/src/commands/general/index.ts
@@ -5,7 +5,7 @@ import info from './info';
 export default category(
   {
     name: 'General',
-    description: 'General commands',
+    description: 'General bot commands.',
     emoji: '📖',
   },
   [help, info]

--- a/src/events/interactionCreate/help.ts
+++ b/src/events/interactionCreate/help.ts
@@ -1,4 +1,4 @@
-import { event, paginationEmbed, parseId } from '../../utils';
+import { event, paginationReply, parseId } from '../../utils';
 import { NAMESPACES } from '../../constants';
 
 export default event('interactionCreate', async (_props, interaction) => {
@@ -7,5 +7,7 @@ export default event('interactionCreate', async (_props, interaction) => {
   if (namespace !== NAMESPACES.help) return;
 
   await interaction.deferUpdate();
-  return await interaction.editReply(paginationEmbed(interaction.values[0]));
+  return await interaction.editReply(
+    await paginationReply(interaction.values[0])
+  );
 });

--- a/src/events/interactionCreate/help.ts
+++ b/src/events/interactionCreate/help.ts
@@ -1,13 +1,16 @@
 import { event, paginationReply, parseId } from '../../utils';
 import { NAMESPACES } from '../../constants';
 
-export default event('interactionCreate', async (_props, interaction) => {
+export default event('interactionCreate', async ({ client }, interaction) => {
   if (!interaction.isStringSelectMenu()) return;
   const [namespace] = parseId(interaction.customId);
   if (namespace !== NAMESPACES.help) return;
 
   await interaction.deferUpdate();
   return await interaction.editReply(
-    await paginationReply(interaction.values[0])
+    await paginationReply(interaction.values[0], {
+      client,
+      interaction,
+    })
   );
 });

--- a/src/events/interactionCreate/pagination.ts
+++ b/src/events/interactionCreate/pagination.ts
@@ -1,7 +1,7 @@
 import { createId, event, generatePage, parseId } from '../../utils';
 import { NAMESPACES } from '../../constants';
 
-export default event('interactionCreate', async (_props, interaction) => {
+export default event('interactionCreate', async ({ client }, interaction) => {
   if (!interaction.isButton() && !interaction.isStringSelectMenu()) return;
   const [namespace, paginatorName] = parseId(interaction.customId);
   if (namespace !== NAMESPACES.pagination) return;
@@ -15,5 +15,10 @@ export default event('interactionCreate', async (_props, interaction) => {
       `select-${interaction.values[0]}`
     );
 
-  return await interaction.editReply(await generatePage(interactionId));
+  return await interaction.editReply(
+    await generatePage(interactionId, {
+      client,
+      interaction,
+    })
+  );
 });

--- a/src/events/interactionCreate/pagination.ts
+++ b/src/events/interactionCreate/pagination.ts
@@ -15,5 +15,5 @@ export default event('interactionCreate', async (_props, interaction) => {
       `select-${interaction.values[0]}`
     );
 
-  return await interaction.editReply(generatePage(interactionId));
+  return await interaction.editReply(await generatePage(interactionId));
 });

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -37,17 +37,19 @@ export interface Command {
   options: CommandOptions;
 }
 
+export interface CommandCategoryCommands {
+  public: Command[];
+  private: Command[];
+  all: Command[];
+}
+
 export interface CommandCategoryMetadata {
   name: string;
   description?: string;
   emoji?: string;
 }
 export interface CommandCategory extends CommandCategoryMetadata {
-  commands: {
-    public: Command[];
-    private: Command[];
-    all: Command[];
-  };
+  commands: CommandCategoryCommands;
 }
 /** Fields for each category page */
 export interface CommandCategoryPage extends CommandCategoryMetadata {

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,3 +1,9 @@
-import { APIEmbedField } from 'discord.js';
+import { APIEmbedField, Client, GuildMember } from 'discord.js';
 
 export type PaginatorData = APIEmbedField[];
+
+export interface PaginationProps {
+  client: Client;
+  guildId: string;
+  member: GuildMember;
+}

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,9 +1,8 @@
-import { APIEmbedField, Client, GuildMember } from 'discord.js';
+import { APIEmbedField, BaseInteraction, Client } from 'discord.js';
 
 export type PaginatorData = APIEmbedField[];
 
 export interface PaginationProps {
   client: Client;
-  guildId: string;
-  member: GuildMember;
+  interaction: BaseInteraction;
 }

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,6 +1,6 @@
 import { APIEmbedField, BaseInteraction, Client } from 'discord.js';
 
-export type PaginatorData = APIEmbedField[];
+export type PaginationData = APIEmbedField[];
 
 export interface PaginationProps {
   client: Client;

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -1,6 +1,7 @@
 import {
   Command,
   CommandCategory,
+  CommandCategoryCommands,
   CommandCategoryMetadata,
   CommandExec,
   CommandMeta,
@@ -40,7 +41,7 @@ export function category(
  */
 export function extractMeta(
   categories: CommandCategory[],
-  type: keyof CommandCategory['commands']
+  type: keyof CommandCategoryCommands
 ) {
   return categories.flatMap(({ commands }) =>
     commands[type].map(({ meta }) => meta)

--- a/src/utils/help.ts
+++ b/src/utils/help.ts
@@ -1,29 +1,68 @@
 import {
   ActionRowBuilder,
   BaseInteraction,
+  PermissionFlagsBits,
   StringSelectMenuBuilder,
 } from 'discord.js';
 import { NAMESPACES } from '../constants';
 import { createId } from './interaction';
 import categories from '../commands';
+import { ENV } from '../env';
+import { CommandCategoryCommands } from '../types';
+
+/**
+ * Filters categories to exclude ones that do not contain commands relevant to the user
+ * @param cmdType The type of command to filter for
+ * @param isAdmin Whether the user is an admin
+ * @returns An array of categories that contain commands relevant to the user
+ */
+const filterCategories = (
+  cmdType: keyof CommandCategoryCommands,
+  isAdmin = false
+) =>
+  categories.filter((c) =>
+    c.commands[cmdType].some((cmd) => !cmd.options.adminOnly || isAdmin)
+  );
+
+/** Pre-filtered command categories */
+const cats = {
+  private: {
+    member: filterCategories('all'),
+    admin: filterCategories('all', true),
+  },
+  public: {
+    member: filterCategories('public'),
+    admin: filterCategories('public', true),
+  },
+};
 
 /** Select menu for the help embed */
 export const helpSelectComponent = (
   interaction: BaseInteraction
-): ActionRowBuilder<StringSelectMenuBuilder> =>
-  new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-    new StringSelectMenuBuilder({
-      custom_id: createId(NAMESPACES.help),
-      placeholder: 'Select a category...',
-      max_values: 1,
-      // Filter out categories with no public commands
-      options: categories
-        ?.filter((c) => c.commands.public.length > 0)
-        .map(({ name, description, emoji }) => ({
-          label: name,
-          description,
-          emoji,
-          value: name,
-        })),
-    })
+): ActionRowBuilder<StringSelectMenuBuilder> | null => {
+  const isAdmin =
+    interaction.memberPermissions &&
+    interaction.memberPermissions.has(PermissionFlagsBits.Administrator);
+  // Categories specific to this guild (test guild or not)
+  const guildCats =
+    interaction.guildId === ENV.TEST_GUILD ? cats.private : cats.public;
+
+  if (guildCats[isAdmin ? 'admin' : 'member'].length === 0) return null;
+
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(createId(NAMESPACES.help))
+      .setPlaceholder('Select a category...')
+      .setMaxValues(1)
+      .addOptions(
+        guildCats[isAdmin ? 'admin' : 'member'].map(
+          ({ name, description, emoji }) => ({
+            label: name,
+            description,
+            emoji,
+            value: name,
+          })
+        )
+      )
   );
+};

--- a/src/utils/help.ts
+++ b/src/utils/help.ts
@@ -1,10 +1,16 @@
-import { ActionRowBuilder, StringSelectMenuBuilder } from 'discord.js';
+import {
+  ActionRowBuilder,
+  BaseInteraction,
+  StringSelectMenuBuilder,
+} from 'discord.js';
 import { NAMESPACES } from '../constants';
 import { createId } from './interaction';
 import categories from '../commands';
 
 /** Select menu for the help embed */
-export const helpSelectComponent =
+export const helpSelectComponent = (
+  interaction: BaseInteraction
+): ActionRowBuilder<StringSelectMenuBuilder> =>
   new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
     new StringSelectMenuBuilder({
       custom_id: createId(NAMESPACES.help),

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -10,7 +10,7 @@ import {
 import { createId } from './interaction';
 import { COLORS, NAMESPACES } from '../constants';
 import { Logger } from './logger';
-import { PaginatorData } from '../types';
+import { PaginationProps, PaginatorData } from '../types';
 
 export class Paginator {
   name: string;
@@ -27,7 +27,7 @@ export class Paginator {
   /** The number of fields to display on a single page (max 25). */
   pageLength: number;
   /** Asynchronous function to fetch the data for the paginator */
-  getData: () => Promise<PaginatorData>;
+  getData: (props: PaginationProps) => Promise<PaginatorData>;
 
   private logger: Logger;
 
@@ -91,8 +91,11 @@ export class Paginator {
    * @param offset The offset to get the page at
    * @returns The interaction reply options for the page at the given offset
    */
-  public async getPage(offset: number): Promise<InteractionReplyOptions> {
-    const data = await this.getData();
+  public async getPage(
+    offset: number,
+    props: PaginationProps
+  ): Promise<InteractionReplyOptions> {
+    const data = await this.getData(props);
     return this.formatPage(offset, data);
   }
 

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -9,7 +9,7 @@ import {
 } from 'discord.js';
 import { createId } from './interaction';
 import { COLORS, NAMESPACES } from '../constants';
-import { log } from './logger';
+import { Logger } from './logger';
 import { PaginatorData } from '../types';
 
 export class Paginator {
@@ -29,6 +29,8 @@ export class Paginator {
 
   data: PaginatorData;
   pageCount: number;
+
+  logger: Logger;
 
   constructor(
     /** Name of the paginator */
@@ -54,10 +56,11 @@ export class Paginator {
       data: typeof Paginator.prototype.data;
     }
   ) {
+    this.logger = new Logger(`paginators/${name}`);
+
     // Page length can be at most 25 due to limit of 25 fields per embed
     if (pageLength > 25) {
-      log.error(
-        'paginators',
+      this.logger.error(
         `Paginator "${name}" has a page length greater than 25`
       );
       process.exit(1);
@@ -66,14 +69,14 @@ export class Paginator {
     // Components can have at most 3 rows, because of the 5 component limit on embeds
     // (2 are already being used for back/next buttons and page selector)
     if (replyOptions.components && replyOptions.components.length > 3) {
-      log.error('paginators', `Paginator "${name}" has more than 3 components`);
+      this.logger.error(`Paginator "${name}" has more than 3 components`);
       process.exit(1);
     }
 
     // The replyOptions can have at most 4 embeds, because of the 5 embed limit on replies
     // (1 is already being used for the pagination embed)
     if (replyOptions.embeds && replyOptions.embeds.length > 4) {
-      log.error('paginators', `Paginator "${name}" has more than 4 embeds`);
+      this.logger.error(`Paginator "${name}" has more than 4 embeds`);
       process.exit(1);
     }
 

--- a/src/utils/paginators/help.ts
+++ b/src/utils/paginators/help.ts
@@ -64,6 +64,13 @@ const getCommands = (command: Command): PaginationData => {
   return result;
 };
 
+/**
+ * Filters commands by type and adminOnly, then extracts subcommands from each command, and flattens the result
+ * @param commands The commands to filter
+ * @param type The type of commands to filter
+ * @param isAdmin Whether the commands should be filtered for admin only
+ * @returns An array of embed fields for each command, comprising the name and description of the command
+ */
 const filterCommands = (
   commands: CommandCategoryCommands,
   type: keyof CommandCategoryCommands,
@@ -76,6 +83,7 @@ const filterCommands = (
 
 const helpPaginators: Paginator[] =
   categories?.map((category) => {
+    // Separate commands into different categories depending on the guild and member that the command is used in/by
     const cmds = {
       private: {
         member: filterCommands(category.commands, 'private'),

--- a/src/utils/paginators/help.ts
+++ b/src/utils/paginators/help.ts
@@ -3,7 +3,7 @@ import {
   ApplicationCommandOptionType,
 } from 'discord.js';
 import categories from '../../commands';
-import { Command, PaginatorData } from '../../types';
+import { Command, PaginationData } from '../../types';
 import { helpSelectComponent } from '../help';
 import { Paginator } from '../pagination';
 
@@ -16,8 +16,8 @@ import { Paginator } from '../pagination';
 const extractSubcommandsRecursive = (
   option: APIApplicationCommandOption,
   name: string
-): PaginatorData => {
-  const result: PaginatorData = [];
+): PaginationData => {
+  const result: PaginationData = [];
   if (option.type === ApplicationCommandOptionType.Subcommand)
     result.push({
       name: `/${name} ${option.name}`,
@@ -35,7 +35,7 @@ const extractSubcommandsRecursive = (
  * @param command The command to get subcommands for
  * @returns An array of embed fields for each command, comprising the name and description of the command
  */
-const getCommands = (command: Command): PaginatorData => {
+const getCommands = (command: Command): PaginationData => {
   const result = command.meta.options
     .map((option) =>
       extractSubcommandsRecursive(option.toJSON(), command.meta.name)

--- a/src/utils/paginators/help.ts
+++ b/src/utils/paginators/help.ts
@@ -69,7 +69,7 @@ const helpPaginators: Paginator[] =
         components: [helpSelectComponent],
       },
       pageLength: 10,
-      data: items,
+      getData: async () => items,
     });
   }) ?? [];
 

--- a/src/utils/paginators/help.ts
+++ b/src/utils/paginators/help.ts
@@ -67,7 +67,7 @@ const getCommands = (command: Command): PaginationData => {
         ${command.meta.description}
         ${command.options.adminOnly ? '🛡️ _admin only_' : ''}${
         command.options.private
-          ? `${command.options.adminOnly && '\n'}🔒 _private_`
+          ? `${command.options.adminOnly ? '\n' : ''}🔒 _private_`
           : ''
       }
       `,
@@ -116,9 +116,12 @@ const helpPaginators: Paginator[] =
             category.commands.public.length > 1 ? 's' : ''
           } in ${emoji}${category.name}`,
       },
-      replyOptions: ({ interaction }) => ({
-        components: [helpSelectComponent(interaction)],
-      }),
+      replyOptions: ({ interaction }) => {
+        const helpSelectMenu = helpSelectComponent(interaction);
+        return {
+          components: helpSelectMenu ? [helpSelectMenu] : [],
+        };
+      },
       pageLength: 10,
       getData: async ({ interaction }) => {
         const guildCmds =

--- a/src/utils/paginators/index.ts
+++ b/src/utils/paginators/index.ts
@@ -3,6 +3,7 @@ import { Paginator } from '../pagination';
 import helpPaginators from './help';
 import { createId, parseId } from '../interaction';
 import { NAMESPACES } from '../../constants';
+import { PaginationProps } from '../../types';
 
 // Add new paginators here
 const paginators: Paginator[] = [...helpPaginators /*, otherPaginator */];
@@ -17,7 +18,8 @@ const paginatorMap = new Map<string, Paginator>(
  * @returns The generated embed
  */
 export async function generatePage(
-  interactionId: string
+  interactionId: string,
+  props: PaginationProps
 ): Promise<InteractionReplyOptions> {
   // Extract metadata from interactionId
   const [_namespace, paginatorName, offsetString] = parseId(interactionId);
@@ -34,7 +36,7 @@ export async function generatePage(
   }
   if (isNaN(offset)) offset = 0;
 
-  return paginator.getPage(offset);
+  return paginator.getPage(offset, props);
 }
 
 /**
@@ -42,7 +44,7 @@ export async function generatePage(
  * @param paginatorName The name of the paginator to generate the reply for
  * @returns The generated reply options
  */
-export function paginationReply(paginatorName: string) {
+export function paginationReply(paginatorName: string, props: PaginationProps) {
   const id = createId(NAMESPACES.pagination, paginatorName);
-  return generatePage(id);
+  return generatePage(id, props);
 }

--- a/src/utils/paginators/index.ts
+++ b/src/utils/paginators/index.ts
@@ -16,7 +16,9 @@ const paginatorMap = new Map<string, Paginator>(
  * @param interactionId The interactionId to generate the page for
  * @returns The generated embed
  */
-export function generatePage(interactionId: string): InteractionReplyOptions {
+export async function generatePage(
+  interactionId: string
+): Promise<InteractionReplyOptions> {
   // Extract metadata from interactionId
   const [_namespace, paginatorName, offsetString] = parseId(interactionId);
 
@@ -36,11 +38,11 @@ export function generatePage(interactionId: string): InteractionReplyOptions {
 }
 
 /**
- * Create a paginated embed for a specific paginator
- * @param paginatorName The name of the paginator to generate the embed for
- * @returns The generated embed
+ * Create a paginated reply for a specific paginator
+ * @param paginatorName The name of the paginator to generate the reply for
+ * @returns The generated reply options
  */
-export function paginationEmbed(paginatorName: string) {
+export function paginationReply(paginatorName: string) {
   const id = createId(NAMESPACES.pagination, paginatorName);
   return generatePage(id);
 }


### PR DESCRIPTION
# Changes
- [x] Rework Paginator class parameters, and allow functions for the `replyOptions` and `embedData` to configure them based on the interaction or bot client
- [x] Add a `Logger` instance to the Paginator class, to replace the separate uses of the `log()` function
- [x] Add support for asynchronous data fetching to the pagination
- [x] Add context props, including bot client and interaction, to the pagination functions (to allow for customizing the data and response to the current user, guild, or whatever else you might want)
- [x] Add option to cache pagination data, keys for which are generated using the specified `getCacheKey()` function
- [x] Update the help menu (for `/help` command) to show only commands that are relevant to the user who uses the command (`private` commands only shown in test guild and `adminOnly` commands only shown to admins)
- [x] Add tags for when a command is `private` or `adminOnly` to the help menu